### PR TITLE
Delete (not working) hit count from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # applied-ml
 Curated papers, articles, and blogs on **data science & machine learning in production**. ⚙️
 
-[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](./CONTRIBUTING.md) [![Summaries](https://img.shields.io/badge/summaries-in%20tweets-%2300acee.svg?style=flat)](https://twitter.com/eugeneyan/status/1350509546133811200) ![HitCount](http://hits.dwyl.com/eugeneyan/applied-ml.svg)
+[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](./CONTRIBUTING.md) [![Summaries](https://img.shields.io/badge/summaries-in%20tweets-%2300acee.svg?style=flat)](https://twitter.com/eugeneyan/status/1350509546133811200)
 
 Figuring out how to implement your ML project? Learn how other organizations did it:
 


### PR DESCRIPTION
The hit count link at the Readme does not work, therefore it should be deleted.
See issue https://github.com/dwyl/hits/issues/89