### PR TITLE
Add ArXivist project to Infra section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,8 +581,9 @@ P.P.S, Looking for guides and interviews on applying ML? 👉[`applyingML`](http
 5. [A closer look at how LinkedIn integrates fairness into its AI products](https://engineering.linkedin.com/blog/2022/a-closer-look-at-how-linkedin-integrates-fairness-into-its-ai-pr) `LinkedIn` `2022`
 
 ## Infra
-1. [Reengineering Facebook AI’s Deep Learning Platforms for Interoperability](https://ai.facebook.com/blog/reengineering-facebook-ais-deep-learning-platforms-for-interoperability) `Facebook` `2020`
-2. [Elastic Distributed Training with XGBoost on Ray](https://eng.uber.com/elastic-xgboost-ray/) `Uber` `2021`
+1. [ArXivist](https://github.com/qosi-org/arxivist) A multi-agent engine that automates the implementation of research papers into verifiable codebases using Scientific Intermediate Representation (SIR). 'QOSI' '2026'
+2. [Reengineering Facebook AI’s Deep Learning Platforms for Interoperability](https://ai.facebook.com/blog/reengineering-facebook-ais-deep-learning-platforms-for-interoperability) `Facebook` `2020`
+3. [Elastic Distributed Training with XGBoost on Ray](https://eng.uber.com/elastic-xgboost-ray/) `Uber` `2021`
 
 ## MLOps Platforms
 1. [Meet Michelangelo: Uber’s Machine Learning Platform](https://eng.uber.com/michelangelo-machine-learning-platform/) `Uber` `2017`


### PR DESCRIPTION
Hi @eugeneyan,

I'd like to contribute ArXivist to the applied-ml list.

ArXivist is a multi-agent engineering engine that addresses the "implementation gap" in production ML. It extracts architecture priors and logic from research papers into a machine-readable SIR (Scientific Intermediate Representation) to generate fully functional, dockerized codebases.

Given the repo's focus on "machine learning in production," we believe ArXivist is a valuable resource for engineers looking to move landmark research into executable environments with high fidelity.

Organization: QOSI

Thank you for maintaining this resource!